### PR TITLE
render_track fields

### DIFF
--- a/configs/schema
+++ b/configs/schema
@@ -50,6 +50,10 @@
             "type": "integer",
             "description": "Any track number greater than this will not be processed"
         },
+        "use_render_track_field":{
+            "type": "boolean",
+            "description": "Wether or not to only render tracks that have the field \"render_track\" set to true"
+        },
         "tracks": {
             "type": "array",
             "minItems": 1,
@@ -64,6 +68,7 @@
             "properties": {
                 "track_number": { "type": "integer" },
                 "title": { "type": "string" },
+                "render_track":{"type":"boolean"},
                 "sub_channels": {
                     "type": "array",
                     "description": "Files which will be mixed together to form the input to the parent track",

--- a/msupcm++/AudioTrack.cpp
+++ b/msupcm++/AudioTrack.cpp
@@ -10,6 +10,7 @@ AudioTrack::AudioTrack(): AudioBase()
 {
 	m_track_number = 0;
 	m_title.clear();
+	m_render_track = false;
 }
 
 
@@ -17,6 +18,7 @@ AudioTrack::AudioTrack(std::fstring_t in): AudioBase(in)
 {
 	m_track_number = 0;
 	m_title.clear();
+	m_render_track = false;
 }
 
 
@@ -24,6 +26,7 @@ AudioTrack::AudioTrack(std::fstring_t in, std::fstring_t out): AudioBase(in, out
 {
 	m_track_number = 0;
 	m_title.clear();
+	m_render_track = false;
 }
 
 
@@ -31,6 +34,7 @@ AudioTrack::AudioTrack(int argc, char** argv) : AudioBase()
 {
     m_track_number = 0;
     m_title.clear();
+	m_render_track = false;
 
     for (int i = 0; i < argc; ++i)
     {
@@ -55,6 +59,7 @@ AudioTrack::AudioTrack(const AudioTrack& a)
 {
 	m_track_number = 0;
 	m_title.clear();
+	m_render_track = false;
 	*this = a;
 }
 
@@ -84,6 +89,7 @@ AudioTrack& AudioTrack::operator=(const AudioTrack& a)
 
 	m_track_number = a.m_track_number;
 	m_title = a.m_title;
+	m_render_track = a.m_render_track;
 
 	return *this;
 }
@@ -123,6 +129,7 @@ void AudioTrack::clear()
 
 	m_track_number = 0;
 	m_title.clear();
+	m_render_track = false;
 }
 
 
@@ -178,4 +185,14 @@ const std::wstring& AudioTrack::title() const
 std::wstring& AudioTrack::title()
 {
 	return m_title;
+}
+
+bool AudioTrack::renderTrack() const
+{
+	return m_render_track;
+}
+
+bool& msu::AudioTrack::renderTrack()
+{
+	return m_render_track;
 }

--- a/msupcm++/AudioTrack.h
+++ b/msupcm++/AudioTrack.h
@@ -37,8 +37,12 @@ namespace msu
 		const std::wstring& title() const;
 		std::wstring& title();
 
+		bool renderTrack() const;
+		bool& renderTrack();
+
 	protected:
 		int m_track_number;
 		std::wstring m_title;
+		bool m_render_track;
 	};
 }

--- a/msupcm++/AudioTrackList.cpp
+++ b/msupcm++/AudioTrackList.cpp
@@ -37,12 +37,25 @@ void AudioTrackList::render()
 		std::wcout << std::endl;
 	}
 
-	for (AudioTrack track : m_tracks)
+	if (config.use_render_field())
 	{
-		if ((track.trackNumber() >= config.first_track()) &&
-			(config.last_track() < 0 || track.trackNumber() <= config.last_track()))
+		for (AudioTrack track : m_tracks)
 		{
-			track.render();
+			if (track.renderTrack())
+			{
+				track.render();
+			}
+		}
+	}
+	else
+	{
+		for (AudioTrack track : m_tracks)
+		{
+			if ((track.trackNumber() >= config.first_track()) &&
+				(config.last_track() < 0 || track.trackNumber() <= config.last_track()))
+			{
+				track.render();
+			}
 		}
 	}
 }

--- a/msupcm++/AudioTrackList.cpp
+++ b/msupcm++/AudioTrackList.cpp
@@ -37,7 +37,7 @@ void AudioTrackList::render()
 		std::wcout << std::endl;
 	}
 
-	if (config.use_render_field())
+	if (config.use_render_track_field())
 	{
 		for (AudioTrack track : m_tracks)
 		{

--- a/msupcm++/GlobalConfig.cpp
+++ b/msupcm++/GlobalConfig.cpp
@@ -20,6 +20,7 @@ unsigned int GlobalConfig::m_verbosity = 2;
 bool GlobalConfig::m_keep_temps = false;
 int GlobalConfig::m_first_track = -1;
 int GlobalConfig::m_last_track = -1;
+bool GlobalConfig::m_use_render_field = false;
 
 std::wstring& GlobalConfig::game()
 {
@@ -85,4 +86,9 @@ int& GlobalConfig::first_track()
 int& GlobalConfig::last_track()
 {
 	return m_last_track;
+}
+
+bool& GlobalConfig::use_render_field()
+{
+	return m_use_render_field;
 }

--- a/msupcm++/GlobalConfig.cpp
+++ b/msupcm++/GlobalConfig.cpp
@@ -20,7 +20,7 @@ unsigned int GlobalConfig::m_verbosity = 2;
 bool GlobalConfig::m_keep_temps = false;
 int GlobalConfig::m_first_track = -1;
 int GlobalConfig::m_last_track = -1;
-bool GlobalConfig::m_use_render_field = false;
+bool GlobalConfig::m_use_render_track_field = false;
 
 std::wstring& GlobalConfig::game()
 {
@@ -88,7 +88,7 @@ int& GlobalConfig::last_track()
 	return m_last_track;
 }
 
-bool& GlobalConfig::use_render_field()
+bool& GlobalConfig::use_render_track_field()
 {
-	return m_use_render_field;
+	return m_use_render_track_field;
 }

--- a/msupcm++/GlobalConfig.h
+++ b/msupcm++/GlobalConfig.h
@@ -23,6 +23,7 @@ namespace msu
 		static bool& keep_temps();
 		static int& first_track();
 		static int& last_track();
+		static bool& use_render_field();
 
 	private:
 		static std::wstring m_game;
@@ -36,5 +37,6 @@ namespace msu
 		static bool m_keep_temps;
 		static int m_first_track;
 		static int m_last_track;
+		static bool m_use_render_field;
 	} config;
 }

--- a/msupcm++/GlobalConfig.h
+++ b/msupcm++/GlobalConfig.h
@@ -23,7 +23,7 @@ namespace msu
 		static bool& keep_temps();
 		static int& first_track();
 		static int& last_track();
-		static bool& use_render_field();
+		static bool& use_render_track_field();
 
 	private:
 		static std::wstring m_game;
@@ -37,6 +37,6 @@ namespace msu
 		static bool m_keep_temps;
 		static int m_first_track;
 		static int m_last_track;
-		static bool m_use_render_field;
+		static bool m_use_render_track_field;
 	} config;
 }

--- a/msupcm++/TrackParser.hpp
+++ b/msupcm++/TrackParser.hpp
@@ -76,6 +76,7 @@ namespace msu {
 
 		j["track_number"] = a.trackNumber();
 		j["title"] = a.title();
+		j["render_track"] = a.renderTrack();
 	}
 
 
@@ -92,7 +93,8 @@ namespace msu {
 			{ "verbosity", config.verbosity() },
 			{ "keep_temps", config.keep_temps() },
 			{ "first_track", config.first_track() },
-			{ "last_track", config.last_track() }
+			{ "last_track", config.last_track() },
+			{ "use_render_field", config.use_render_field() }
 		};
 
 		for (auto i = a.tracks().begin(); i != a.tracks().end(); ++i)
@@ -260,6 +262,9 @@ namespace msu {
 		if (j.find("title") != j.end())
 			a.title() = utf8_to_wstring.from_bytes(j["title"].get<std::string>().c_str());
 
+		if (j.find("render_track") != j.end())
+			a.renderTrack() = j["render_track"].get<bool>();
+
 		if (a.outFile().empty())
 #ifdef WIN32
 			a.outFile() = config.output_prefix() + L"-" + std::to_wstring(a.trackNumber()) + L".pcm";
@@ -334,6 +339,9 @@ namespace msu {
 
 		if (j.find("last_track") != j.end())
 			config.last_track() = j["last_track"].get<int>();
+
+		if (j.find("use_render_field") != j.end())
+			config.use_render_field() = j["use_render_field"].get<bool>();
 
 		if (j.find("tracks") != j.end())
 		{

--- a/msupcm++/TrackParser.hpp
+++ b/msupcm++/TrackParser.hpp
@@ -94,7 +94,7 @@ namespace msu {
 			{ "keep_temps", config.keep_temps() },
 			{ "first_track", config.first_track() },
 			{ "last_track", config.last_track() },
-			{ "use_render_field", config.use_render_field() }
+			{ "use_render_track_field", config.use_render_track_field() }
 		};
 
 		for (auto i = a.tracks().begin(); i != a.tracks().end(); ++i)
@@ -340,8 +340,8 @@ namespace msu {
 		if (j.find("last_track") != j.end())
 			config.last_track() = j["last_track"].get<int>();
 
-		if (j.find("use_render_field") != j.end())
-			config.use_render_field() = j["use_render_field"].get<bool>();
+		if (j.find("use_render_track_field") != j.end())
+			config.use_render_track_field() = j["use_render_track_field"].get<bool>();
 
 		if (j.find("tracks") != j.end())
 		{


### PR DESCRIPTION
Added 2 new json fields that enable per track rendering
- use_render_track_field in GlobalConfig
- render_track in AudioTrack
- updated schema to include those new fields

When use_render_track_field is true the min and max track fields are ignored and only tracks with render_track set to true are rendered. This makes it easier when you work on a per track basis, since you wont have to scroll up just to increment both min and max track by one anymore. Default behaviour is unchanged.